### PR TITLE
Storage initializer sidecar instead of init container

### DIFF
--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -164,7 +164,7 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 
 	securityContext := userContainer.SecurityContext.DeepCopy()
 	// Add an init container to run provisioning logic to the PodSpec
-	initContainer := &v1.Container{
+	storageInitializerContainer := &v1.Container{
 		Name:  StorageInitializerContainerName,
 		Image: storageInitializerImage,
 		Args: []string{
@@ -206,14 +206,14 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 	if err := mi.credentialBuilder.CreateSecretVolumeAndEnv(
 		pod.Namespace,
 		pod.Spec.ServiceAccountName,
-		initContainer,
+		storageInitializerContainer,
 		&pod.Spec.Volumes,
 	); err != nil {
 		return err
 	}
 
-	// Add init container to the spec
-	pod.Spec.InitContainers = append(pod.Spec.InitContainers, *initContainer)
+	// Add Storage Initializer container as a sidecar
+	pod.Spec.Containers = append(pod.Spec.Containers, *storageInitializerContainer)
 
 	return nil
 }

--- a/python/storage-initializer/scripts/initializer-entrypoint
+++ b/python/storage-initializer/scripts/initializer-entrypoint
@@ -2,7 +2,9 @@
 import sys
 import kfserving
 import logging
+import os
 import time
+import tempfile
 
 if len(sys.argv) != 3:
     print("Usage: initializer-entrypoint src_uri dest_path")
@@ -12,7 +14,15 @@ src_uri = sys.argv[1]
 dest_path = sys.argv[2]
 
 logging.info("Initializing, args: src_uri [%s] dest_path[ [%s]" % (src_uri, dest_path))
-kfserving.Storage.download(src_uri, dest_path)
+
+with tempfile.TemporaryDirectory(prefix=".", dir=dest_path) as tmp_dir:
+    logging.info(f"Downloading staging directory: {tmp_dir}")
+    kfserving.Storage.download(src_uri, tmp_dir)
+    files = os.listdir(tmp_dir)
+    logging.info(f"Files downloaded: {files}")
+    logging.info(f"Copying to target location: {dest_path}")
+    for file in files:
+        os.rename(os.path.join(tmp_dir, file), os.path.join(dest_path, file))
 
 while True:
     time.sleep(60*60)

--- a/python/storage-initializer/scripts/initializer-entrypoint
+++ b/python/storage-initializer/scripts/initializer-entrypoint
@@ -2,6 +2,7 @@
 import sys
 import kfserving
 import logging
+import time
 
 if len(sys.argv) != 3:
     print("Usage: initializer-entrypoint src_uri dest_path")
@@ -12,3 +13,6 @@ dest_path = sys.argv[2]
 
 logging.info("Initializing, args: src_uri [%s] dest_path[ [%s]" % (src_uri, dest_path))
 kfserving.Storage.download(src_uri, dest_path)
+
+while True:
+    time.sleep(60*60)

--- a/python/storage-initializer/scripts/initializer-entrypoint
+++ b/python/storage-initializer/scripts/initializer-entrypoint
@@ -16,13 +16,14 @@ dest_path = sys.argv[2]
 logging.info("Initializing, args: src_uri [%s] dest_path[ [%s]" % (src_uri, dest_path))
 
 with tempfile.TemporaryDirectory(prefix=".", dir=dest_path) as tmp_dir:
-    logging.info(f"Downloading staging directory: {tmp_dir}")
+    logging.info(f"Downloading to staging directory: {tmp_dir}")
     kfserving.Storage.download(src_uri, tmp_dir)
     files = os.listdir(tmp_dir)
     logging.info(f"Files downloaded: {files}")
-    logging.info(f"Copying to target location: {dest_path}")
+    logging.info(f"Moving to target location: {dest_path}")
     for file in files:
-        os.rename(os.path.join(tmp_dir, file), os.path.join(dest_path, file))
+        if not os.path.exists(os.path.join(dest_path, file)):
+          os.rename(os.path.join(tmp_dir, file), os.path.join(dest_path, file))
 
 while True:
     time.sleep(60*60)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes storage initializer from init containers and makes it a sidecar.

**Which issue(s) this PR fixes**
This PR fixes a deadlock on Istio when storage initializer tries to fetch remote data before the networking becomes available. Istio CNI plugin overwrites iptables to route traffic to Envoy proxy, but Envoy proxy is a sidecar which can't start until all init containers complete.