### PR TITLE
[chore] Add Pytorch 1.7.1 and CUDA 11.0 support for pytorchserver

### DIFF
--- a/python/pytorch-gpu.Dockerfile
+++ b/python/pytorch-gpu.Dockerfile
@@ -1,9 +1,9 @@
-FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04 AS BUILD
+FROM nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04 AS BUILD
 
 ARG PYTHON_VERSION=3.7
 ARG CONDA_PYTHON_VERSION=3
 ARG CONDA_DIR=/opt/conda
-ARG PYTORCH_VERSION=1.3.1
+ARG PYTORCH_VERSION=1.7.1
 
 # Instal basic utilities
 RUN apt-get update && \
@@ -21,7 +21,7 @@ RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda$CONDA_PYTHON_VERS
     rm -rf /var/lib/apt/lists/*
 
 RUN conda install -y python=$PYTHON_VERSION && \
-    conda install -y pytorch==$PYTORCH_VERSION torchvision pillow==6.2.0 cudatoolkit=10.0 -c pytorch && \
+    conda install -y pytorch==$PYTORCH_VERSION torchvision pillow==6.2.0 cudatoolkit=11.0 -c pytorch && \
     conda install -y h5py scikit-learn matplotlib seaborn \
     pandas mkl-service cython && \
     conda clean -tipsy

--- a/python/pytorch.Dockerfile
+++ b/python/pytorch.Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ARG PYTORCH_VERSION=1.3.1
+ARG PYTORCH_VERSION=1.7.1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
          build-essential \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Updates Pytorch and CUDA version in `pytorchserver` images to be the same as the current version used in Kaptain.

The following images have been created and used in KFServing `inferenceservice-config` ConfigMap:
```
mesosphere/kubeflow:pytorchserver-v0.5.1-1.7.1
mesosphere/kubeflow:pytorchserver-v0.5.1-1.7.1-gpu